### PR TITLE
Refactor DocumentBuilder

### DIFF
--- a/app/services/geo_works/discovery/document_builder.rb
+++ b/app/services/geo_works/discovery/document_builder.rb
@@ -4,16 +4,15 @@ module GeoWorks
       attr_reader :geo_concern, :document
       delegate :to_json, :to_xml, :to_hash, to: :document
 
+      class_attribute :root_path_class
+
+      # Class used to generate urls for links in the document.
+      self.root_path_class = DocumentPath
+
       def initialize(geo_concern, document)
         @geo_concern = geo_concern
         @document = document
         builders.build(document)
-      end
-
-      # Returns a document path object. Used to get urls for links in the document.
-      # @return [DocumentPath] geoblacklight document as a json string
-      def root_path
-        @root_path ||= DocumentPath.new(geo_concern)
       end
 
       # Instantiates a CompositeBuilder object with an array of
@@ -55,7 +54,7 @@ module GeoWorks
       # Builds service reference fields such as thumbnail and download url.
       # @return [ReferencesBuilder] references builder for document
       def references_builder
-        ReferencesBuilder.new(geo_concern, root_path)
+        ReferencesBuilder.new(geo_concern)
       end
 
       # Instantiates a LayerInfoBuilder object.

--- a/app/services/geo_works/discovery/document_builder/composite_builder.rb
+++ b/app/services/geo_works/discovery/document_builder/composite_builder.rb
@@ -4,8 +4,8 @@ module GeoWorks
       class CompositeBuilder
         attr_reader :services
 
-        def initialize(*services)
-          @services = services.compact
+        def initialize(services)
+          @services = services
         end
 
         # Runs each builder service to build a discovery document.

--- a/app/services/geo_works/discovery/document_builder/references_builder.rb
+++ b/app/services/geo_works/discovery/document_builder/references_builder.rb
@@ -4,9 +4,9 @@ module GeoWorks
       class ReferencesBuilder
         attr_reader :geo_concern, :path
 
-        def initialize(geo_concern, path)
+        def initialize(geo_concern)
           @geo_concern = geo_concern
-          @path = path
+          @path = DocumentBuilder.root_path_class.new(geo_concern)
         end
 
         # Builds service reference fields such as thumbnail and download url.

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -1,0 +1,41 @@
+FactoryGirl.define do
+  factory :permission_template, class: Hyrax::PermissionTemplate do
+    # Given that there is a one to one strong relation between permission_template and admin_set,
+    # with a unique index on the admin_set_id, I don't want to have duplication in admin_set_id
+    sequence(:admin_set_id) { |n| format("%010d", n) }
+
+    before(:create) do |permission_template, evaluator|
+      if evaluator.with_admin_set
+        admin_set_id = permission_template.admin_set_id
+        admin_set =
+          if admin_set_id.present?
+            begin
+              AdminSet.find(admin_set_id)
+            rescue
+              create(:admin_set, id: admin_set_id)
+            end
+          else
+            create(:admin_set)
+          end
+        permission_template.admin_set_id = admin_set.id
+      end
+    end
+
+    after(:create) do |permission_template, evaluator|
+      if evaluator.with_workflows
+        Hyrax::Workflow::WorkflowImporter.load_workflow_for(permission_template: permission_template)
+        Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: permission_template.available_workflows.pluck(:id).first)
+      end
+      if evaluator.with_active_workflow
+        workflow = create(:workflow, active: true, permission_template: permission_template)
+        create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
+      end
+    end
+
+    transient do
+      with_admin_set false
+      with_workflows false
+      with_active_workflow false
+    end
+  end
+end

--- a/spec/factories/workflows.rb
+++ b/spec/factories/workflows.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :workflow, class: Sipity::Workflow do
     sequence(:name) { |n| "generic_work-#{n}" }
+    permission_template
   end
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,2 +1,1 @@
-gem 'flipflop', github: 'jcoyne/flipflop', branch: 'hydra'
 gem 'hyrax', github: 'projecthydra-labs/hyrax', branch: 'master'

--- a/template.rb
+++ b/template.rb
@@ -1,5 +1,4 @@
-gem 'test_hyrax', '0.0.1.alpha'
-gem 'flipflop', github: 'jcoyne/flipflop', branch: 'hydra'
+gem 'hyrax', '0.0.1.alpha'
 gem 'geo_works'
 
 run 'bundle install'


### PR DESCRIPTION
Refactor document builder to make builder services and root_path_class configurable by the end user. Placing the following in an initializer, for example:

```
GeoWorks::Discovery::DocumentBuilder.root_path_class = CustomPathClass
GeoWorks::Discovery::DocumentBuilder.services = [GeoConcerns::BasicMetadataBuilder, MyCustomBuilder]
```