### PR TITLE
Use embedded geoblacklight schema document

### DIFF
--- a/app/services/geo_works/discovery/geoblacklight_document.rb
+++ b/app/services/geo_works/discovery/geoblacklight_document.rb
@@ -6,9 +6,6 @@ module GeoWorks
     # For details on the schema,
     # @see 'https://github.com/geoblacklight/geoblacklight/wiki/Schema'
     class GeoblacklightDocument < AbstractDocument
-      GEOBLACKLIGHT_RELEASE_VERSION = 'v1.1.2'.freeze
-      GEOBLACKLIGHT_SCHEMA = JSON.parse(open("https://raw.githubusercontent.com/geoblacklight/geoblacklight/#{GEOBLACKLIGHT_RELEASE_VERSION}/schema/geoblacklight-schema.json").read).freeze
-
       # Implements the to_hash method on the abstract document.
       # @param _args [Array<Object>] arguments needed for the renderer, unused here
       # @return [Hash] geoblacklight document as a hash
@@ -111,19 +108,25 @@ module GeoWorks
         # Returns the content of geoblacklight JSON-Schema document.
         # @return [Hash] geoblacklight json schema
         def schema
-          GEOBLACKLIGHT_SCHEMA
+          JSON.parse(File.read(schema_path))
+        end
+
+        # Returns a path to the geoblackligh schema document
+        # @return [String]
+        def schema_path
+          File.join(GeoWorks.root, 'config', 'discovery', 'geoblacklight-schema.json')
         end
 
         # Validates the geoblacklight document against the json schema.
         # @return [Boolean] is the document valid?
         def valid?(doc)
-          JSON::Validator.validate(schema, doc, fragment: '#/properties/layer')
+          JSON::Validator.validate(schema, doc, fragment: '#/definitions/layer')
         end
 
         # Returns a hash of errors from json schema validation.
         # @return [Hash] json schema validation errors
         def schema_errors(doc)
-          { error: JSON::Validator.fully_validate(schema, doc, fragment: '#/properties/layer') }
+          { error: JSON::Validator.fully_validate(schema, doc, fragment: '#/definitions/layer') }
         end
 
         # Cleans the geoblacklight document hash by removing unused fields,

--- a/config/discovery/geoblacklight-schema.json
+++ b/config/discovery/geoblacklight-schema.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Schema for GeoBlacklight. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more details.",
+  "id": "http://geoblacklight.org/v1.0/schema",
+  "title": "GeoBlacklight Schema",
+  "definitions": {
+    "layer": {
+      "title": "layer",
+      "description": "A GIS data layer. See [this example](https://github.com/OpenGeoMetadata/edu.stanford.purl/blob/master/bb/099/zb/1450/geoblacklight.json) metadata layer.",
+      "type": "object",
+      "required": [
+        "dc_title_s",
+        "dc_identifier_s",
+        "dc_rights_s",
+        "dct_provenance_s",
+        "layer_slug_s",
+        "solr_geom"
+      ],
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `dc_identifier_s`): Unique identifier for layer that is globally unique.",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_identifier_s": {
+          "type": "string",
+          "description": "Unique identifier for layer as a URI. It should be globally unique across all institutions, assumed not to be end-user visible, and is usually of the form `http://institution/id`. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_title_s": {
+          "type": "string",
+          "description": "Title for the layer.",
+          "example": "My Title"
+        },
+        "dc_description_s": {
+          "type": "string",
+          "description": "Description for the layer. *Optional*",
+          "example": "My Description"
+        },
+        "dc_rights_s": {
+          "type": "string",
+          "enum": [
+            "Public",
+            "Restricted"
+          ],
+          "description": "Access rights for the layer."
+        },
+        "dct_provenance_s": {
+          "type": "string",
+          "description": "Institution who holds the layer.",
+          "example": "Stanford"
+        },
+        "dct_references_s": {
+          "type": "string",
+          "description": "External resources that are available for the layer. The value is a JSON hash where each key is a URI for the protocol or format, and the value is the URL to the external resource. See `dct_references_s` [detailed documentation](http://geoblacklight.org/tutorial/2015/02/09/geoblacklight-overview.html). *Optional*",
+          "pattern": "\\{.*\\}",
+          "example": "{ ... }"
+        },
+        "georss_box_s": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `solr_geom`): Bounding box for the layer, as maximum values for S W N E.",
+          "example": "12.6 -119.4 19.9 84.8"
+        },
+        "layer_id_s": {
+          "type": "string",
+          "description": "The complete identifier for the layer via WMS/WFS/WCS protocol. *Optional*",
+          "example": "druid:vr593vj7147"
+        },
+        "layer_geom_type_s": {
+          "type": "string",
+          "enum": [
+            "Point",
+            "Line",
+            "Polygon",
+            "Raster",
+            "Scanned Map",
+            "Image",
+            "Mixed"
+          ],
+          "description": "Geometry type for layer data, using controlled vocabulary. *Optional*"
+        },
+        "layer_modified_dt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modification date for the metadata record, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional*"
+        },
+        "layer_slug_s": {
+          "type": "string",
+          "description": "Identifies a layer in human-readable keywords. Note this value is visible to the user, and used for Permalinks. The value should be alpha-numeric characters separated by dashes, and is typically of the form `institution-keyword1-keyword2`. It should also be globally unique across all institutions in *your* GeoBlacklight index. See https://github.com/geoblacklight/geoblacklight/wiki/Schema for more detailed documentation.",
+          "pattern": "^[-a-zA-Z0-9]+$",
+          "example": "stanford-andhra-pradesh-village-boundaries"
+        },
+        "solr_geom": {
+          "type": "string",
+          "pattern": "ENVELOPE(.*,.*,.*,.*)",
+          "description": "Bounding box of the layer as a ENVELOPE WKT (from the CQL standard) using coordinates in (West, East, North, South) order. Note that this field is indexed as a Solr spatial (RPT) field.",
+          "example": "ENVELOPE(76.76, 84.76, 19.91, 12.62)"
+        },
+        "solr_year_i": {
+          "type": "integer",
+          "description": "*DEPRECATED* (only used by the Blacklight range plugin, not core GeoBlacklight, and generally you want a multi-valued field here): *Derived from* `dct_temporal_sm`. Year for which layer is valid and only a single value. Note that this field is indexed as a Solr numeric field.",
+          "example": "1989"
+        },
+        "dc_creator_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Author(s) of the layer. *Optional*",
+          "example": "George Washington, Thomas Jefferson"
+        },
+        "dc_format_s": {
+          "type": "string",
+          "description": "File format for the layer, ideally using a controlled vocabulary. *Optional*",
+          "example": "Shapefile, GeoTIFF, ArcGRID"
+        },
+        "dc_language_s": {
+          "type": "string",
+          "description": "Language for the layer. *Optional*. Note that future versions of the schema may make this a multi-valued field.",
+          "example": "English"
+        },
+        "dc_publisher_s": {
+          "type": "string",
+          "description": "Publisher of the layer. *Optional*",
+          "example": "ML InfoMap"
+        },
+        "dc_subject_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Subjects for the layer, preferrably in a controlled vocabulary. *Optional*",
+          "example": "Census, Human settlements"
+        },
+        "dc_type_s": {
+          "type": "string",
+          "enum": [
+            "Dataset",
+            "Image",
+            "PhysicalObject"
+          ],
+          "description": "Resource type of the layer, using DCMI Type Vocabulary, usually a `Dataset`. *Optional*"
+        },
+        "dct_spatial_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Spatial coverage and place names for the layer, preferrably in a controlled vocabulary. *Optional*",
+          "example": "Paris, San Francisco"
+        },
+        "dct_temporal_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Temporal coverage for the layer, typically years or dates. Note that this field is not in a specific date format. *Optional*",
+          "example": "1989, circa 2010, 2007-2009"
+        },
+        "dct_issued_dt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Issued date for the layer, using XML Schema dateTime format (YYYY-MM-DDThh:mm:ssZ). *Optional*"
+        },
+        "dct_isPartOf_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Holding entity for the layer, such as the title of a collection. *Optional*",
+          "example": "Village Maps of India"
+        },
+        "georss_point_s": {
+          "type": "string",
+          "description": "*DEPRECATED* (use `georss_box_s`): Point representation for layer as y, x - i.e., centroid",
+          "example": "12.6 -119.4"
+        },
+        "dc_relation_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "*DEPRECATED* (use `dct_isPartOf_sm`). A reference to a related resource for this layer. *Optional*",
+          "example": "http://purl.stanford.edu/vr593vj7147"
+        },
+        "dc_source_sm": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The identity of a layer from which this layer's data was derived. *Optional*",
+          "example": "stanford-vr593vj7147"
+        },
+        "geoblacklight_version": {
+          "type": "string",
+          "description": "The version of the GeoBlacklight Schema to which this metadata record conforms.",
+          "enum": [
+            "1.0"
+          ]
+        }
+      }
+    }
+  },
+  "anyOf": [
+    {
+      "$ref": "#/definitions/layer"
+    }, {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/layer"
+      }
+    }
+  ]
+}

--- a/spec/services/geo_works/discovery/geoblacklight_document_spec.rb
+++ b/spec/services/geo_works/discovery/geoblacklight_document_spec.rb
@@ -11,7 +11,7 @@ describe GeoWorks::Discovery::GeoblacklightDocument do
     context 'incomplete data' do
       let(:document_hash) { Hash.new }
 
-      it 'failed to validate the document hash' do
+      it 'fails to validate the document hash' do
         expect(subject.to_hash).to include(:error)
         expect(subject.to_hash[:error].size).to eq(6)
       end


### PR DESCRIPTION
Use embedded geoblacklight schema document instead of pulling a copy from Github. Closes #12.