### PR TITLE
string sql syntax adjustment in shapelayer rendering

### DIFF
--- a/app/processors/geo_works/processors/rendering.rb
+++ b/app/processors/geo_works/processors/rendering.rb
@@ -41,7 +41,7 @@ module GeoWorks
           def add_shapefile_layer(in_path, map)
             Dir.glob("#{in_path}/*.shp").each do |shp|
               map.layer shp do |l|
-                l.query "select * from '#{File.basename shp, '.shp'}'" do |q|
+                l.query %(select * from "#{File.basename shp, '.shp'}") do |q|
                   q.styles SimplerTiles.config.to_h
                 end
               end


### PR DESCRIPTION
This commit fixes an error that occurs as a result of upgrading gdal/simpler_tiles, because gdal 2 is employing stricter quoting (strict SQL92, http://www.gdal.org/ogr_sql.html) rules. 